### PR TITLE
Bump sitemap lastmod (retrigger Pages deploy)

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://movieanimals.net/</loc>
-    <lastmod>2026-07-01</lastmod>
+    <lastmod>2026-07-09</lastmod>
     <priority>1.0</priority>
   </url>
 </urlset>


### PR DESCRIPTION
The Pages deploy for PR #50 (teal bubble band) failed on GitHub's side with no failed jobs — an infra flake — and the integration lacks permission to re-run it. This trivial sitemap `lastmod` bump produces a fresh merge commit to retrigger the Pages build so the already-merged changes actually deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY)_