### PR TITLE
Humanize copy, remove em dashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Toth Movie Animals | Animal Training &amp; On-Set Safety for Film, TV &amp; Commercials</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <meta name="description" content="Toth Movie Animals provides professional animal training, on-set safety, and wildlife management — including rattlesnake abatement — for film, TV, and commercial productions. Based in Los Angeles, available worldwide.">
+  <meta name="description" content="Toth Movie Animals provides animal training, on-set safety, and wildlife management (including rattlesnake abatement) for film, TV, and commercial productions. Based in Los Angeles, available worldwide.">
   <meta name="robots" content="index, follow">
   <meta name="theme-color" content="#FFFFFF">
   <link rel="canonical" href="https://movieanimals.net/">
@@ -729,7 +729,7 @@
     <section class="container hero">
       <div>
         <h1 class="reveal">Animal talent &amp; <span class="accent">on-set safety</span> for film and TV.</h1>
-        <p class="hero-sub reveal">Professional animal training, certified safety coordination, and wildlife management for productions of all sizes.</p>
+        <p class="hero-sub reveal">Trained animals, certified safety coordination, and wildlife management for film, TV, and commercial shoots.</p>
         <div class="cta-row reveal">
           <a href="#contact" class="btn btn-primary">Start a conversation</a>
           <a href="https://www.imdb.com/name/nm14670166/" class="btn btn-outline" target="_blank" rel="noopener noreferrer">View IMDb <span class="arrow" aria-hidden="true">&nearr;</span></a>
@@ -761,29 +761,29 @@
     <section id="services" class="section">
       <div class="container">
         <span class="kicker reveal">Services</span>
-        <h2 class="reveal">Every animal. Every set. Handled.</h2>
-        <p class="section-sub reveal">From trained animal talent to clearing a location of wildlife, one team covers it.</p>
+        <h2 class="reveal">What we do</h2>
+        <p class="section-sub reveal">Need a trained animal for a scene, a safety coordinator on set, or a location cleared of rattlesnakes? That&rsquo;s what we do.</p>
         <div class="cards">
           <div class="card reveal">
             <div class="icon-chip">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/></svg>
             </div>
             <h3>Animal Training</h3>
-            <p>Professional animal talent, trained and handled for film, TV, and commercial productions of every scale.</p>
+            <p>Trained animals for film, TV, and commercials, handled on set by a professional.</p>
           </div>
           <div class="card reveal">
             <div class="icon-chip">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
             </div>
             <h3>On-Set Safety</h3>
-            <p>Certified safety protocols and coordination that keep cast, crew, and animals protected on set.</p>
+            <p>Certified safety coordination that keeps your cast, crew, and animals safe while cameras roll.</p>
           </div>
           <div class="card reveal">
             <div class="icon-chip">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 22c1.25-.987 2.27-1.975 3.9-2.2a5.56 5.56 0 0 1 3.8 1.5 4 4 0 0 0 6.187-2.353 3.5 3.5 0 0 0 3.69-5.116A3.5 3.5 0 0 0 20.95 8 3.5 3.5 0 1 0 16 3.05a3.5 3.5 0 0 0-5.831 1.373 3.5 3.5 0 0 0-5.116 3.69 4 4 0 0 0-2.348 6.155C3.499 15.42 4.409 16.712 4.2 18.1 3.926 19.743 3.014 20.732 2 22"/></svg>
             </div>
             <h3>Wildlife Management</h3>
-            <p>Expert wildlife handling and location clearing, including professional rattlesnake abatement.</p>
+            <p>Wildlife handling and location clearing, including rattlesnake abatement.</p>
           </div>
         </div>
       </div>
@@ -793,7 +793,7 @@
     <section id="work" class="section alt">
       <div class="container">
         <span class="kicker reveal">On Set</span>
-        <h2 class="reveal">Real work, real productions.</h2>
+        <h2 class="reveal">Some of our recent work</h2>
         <div class="gallery">
           <!-- To add a photo: drop the file in assets/img/ and copy this figure block -->
           <figure class="reveal">
@@ -819,8 +819,8 @@
       <div class="container about-inner">
         <span class="kicker reveal">About</span>
         <h2 class="reveal">Led by Derek Toth.</h2>
-        <p class="reveal"><strong>Derek Toth</strong> is an animal trainer and safety coordinator who brings calm, certified expertise to productions of all sizes — specializing in animal handling, on-set safety protocols, and wildlife management including rattlesnake abatement.</p>
-        <p class="reveal">Proud to offer certified safety services in partnership with <a href="https://theanimalprotectionagency.org/derek-toth-2/" target="_blank" rel="noopener noreferrer" class="text-link">The Animal Protection Agency</a> <img src="https://i0.wp.com/theanimalprotectionagency.org/wp-content/uploads/2021/01/APA-LOGO-2021-Tiny.png?fit=32%2C32&ssl=1" alt="APA Logo" class="apa-logo" width="20" height="20" loading="lazy"></p>
+        <p class="reveal"><strong>Derek Toth</strong> is an animal trainer and safety coordinator based in Los Angeles. He handles everything from trained dogs to rattlesnake removal and has worked on productions of every size.</p>
+        <p class="reveal">Derek offers certified safety services in partnership with <a href="https://theanimalprotectionagency.org/derek-toth-2/" target="_blank" rel="noopener noreferrer" class="text-link">The Animal Protection Agency</a> <img src="https://i0.wp.com/theanimalprotectionagency.org/wp-content/uploads/2021/01/APA-LOGO-2021-Tiny.png?fit=32%2C32&ssl=1" alt="APA Logo" class="apa-logo" width="20" height="20" loading="lazy"></p>
       </div>
     </section>
 
@@ -830,7 +830,7 @@
         <div>
           <span class="kicker reveal">Contact</span>
           <h2 class="reveal">Let&rsquo;s talk about your production.</h2>
-          <p class="section-sub reveal">Tell us what your shoot needs — we&rsquo;ll take it from there.</p>
+          <p class="section-sub reveal">Tell us what your shoot needs and we&rsquo;ll take it from there.</p>
           <div class="contact-row reveal">
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg>
             Los Angeles, California


### PR DESCRIPTION
Copy pass on the redesign per owner feedback:

- Every em dash removed from page copy and the meta description
- Plain-spoken rewrites throughout: services intro is now a direct question, card copy shortened, the about section reads like a bio instead of marketing copy
- Slogan-style headings ("Every animal. Every set. Handled.", "Real work, real productions.") replaced with plain ones ("What we do", "Some of our recent work")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY)_