### PR TITLE
Keep APA logo on the same line as the partnership link

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,12 +503,16 @@
       border-bottom-color: var(--teal-hover);
     }
 
+    .nowrap {
+      white-space: nowrap;
+    }
+
     .apa-logo {
       width: 20px;
       height: 20px;
       vertical-align: -4px;
-      margin-left: 3px;
       display: inline-block;
+      border-bottom: none;
     }
 
     /* Contact */
@@ -820,7 +824,7 @@
         <span class="kicker reveal">About</span>
         <h2 class="reveal">Led by Derek Toth.</h2>
         <p class="reveal"><strong>Derek Toth</strong> is an animal trainer and safety coordinator based in Los Angeles. His work spans feature films, television, and commercials, covering animal training, on-set safety, and wildlife management including rattlesnake abatement.</p>
-        <p class="reveal">Derek offers certified safety services in partnership with <a href="https://theanimalprotectionagency.org/derek-toth-2/" target="_blank" rel="noopener noreferrer" class="text-link">The Animal Protection Agency</a> <img src="https://i0.wp.com/theanimalprotectionagency.org/wp-content/uploads/2021/01/APA-LOGO-2021-Tiny.png?fit=32%2C32&ssl=1" alt="APA Logo" class="apa-logo" width="20" height="20" loading="lazy"></p>
+        <p class="reveal">Derek offers certified safety services in partnership with <a href="https://theanimalprotectionagency.org/derek-toth-2/" target="_blank" rel="noopener noreferrer" class="text-link">The Animal Protection <span class="nowrap">Agency&nbsp;<img src="https://i0.wp.com/theanimalprotectionagency.org/wp-content/uploads/2021/01/APA-LOGO-2021-Tiny.png?fit=32%2C32&ssl=1" alt="APA Logo" class="apa-logo" width="20" height="20" loading="lazy"></span></a></p>
       </div>
     </section>
 


### PR DESCRIPTION
Fixes the APA logo wrapping onto its own line in the About section. The logo now sits inside the link, bound to the word "Agency" with a no-wrap span and a non-breaking space, so the pair can never split across lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY)_