### PR TITLE
Refine gallery captions and blurb

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,7 +872,7 @@
       <div class="container">
         <span class="kicker reveal">On Set</span>
         <h2 class="reveal">Recent work</h2>
-        <p class="section-sub reveal">From trained animal talent on camera to safely relocating wildlife that turns up on location.</p>
+        <p class="section-sub reveal">Trained talent in front of the camera. A safe set behind it.</p>
         <div class="gallery">
           <!-- To add a photo: drop the file (plus a .webp twin) in assets/img/ and copy a figure block -->
           <figure class="reveal">
@@ -881,7 +881,7 @@
               <img src="assets/img/gopher-snake-relocation.jpg" alt="Derek Toth holding a juvenile gopher snake on set before relocating it" width="665" height="1182" loading="lazy" decoding="async">
             </picture>
             <figcaption>
-              <span class="cap-title">Juvenile gopher snake</span>
+              <span class="cap-title">Juvenile Gopher Snake</span>
               <span class="cap-detail">Safely captured on set and released to habitat well clear of the production.</span>
             </figcaption>
           </figure>
@@ -901,7 +901,7 @@
               <img src="assets/img/rattlesnake-onset.jpg" alt="A Southern Pacific rattlesnake coiled on the ground, found on a filming location" width="768" height="1024" loading="lazy" decoding="async">
             </picture>
             <figcaption>
-              <span class="cap-title">Southern Pacific rattlesnake</span>
+              <span class="cap-title">Southern Pacific Rattlesnake</span>
               <span class="cap-detail">Identified on a filming location and safely relocated well away from cast and crew.</span>
             </figcaption>
           </figure>
@@ -912,7 +912,7 @@
             </picture>
             <figcaption>
               <span class="cap-title">Deadpool &amp; Wolverine world premiere</span>
-              <span class="cap-detail">On the carpet representing on-set animal work for a major studio release.</span>
+              <span class="cap-detail">Walking the red carpet with a four-legged companion.</span>
             </figcaption>
           </figure>
         </div>


### PR DESCRIPTION
Copy tweaks on the gallery:

- Capitalized the animal names: "Southern Pacific Rattlesnake" and "Juvenile Gopher Snake"
- Red-carpet caption is now specific instead of generic: "Walking the red carpet with a four-legged companion."
- Section blurb tightened with a front/behind play: "Trained talent in front of the camera. A safe set behind it."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyMarrmdyLXRVAGiEMPkSY)_